### PR TITLE
Let users disable whitelisted content-types

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -399,13 +399,13 @@ return [
         'http' => [
             /*
              * Whitelist of loggable http content types
-             * Supports wildcards
-             * Test: tests\Logging\HttpLoggableAwareTraitTest.php
+             * Array keys are the internal type identifier (so that it can be disabled)
+             * Array values are regular expressions that Content-Type headers must satisfy.
              */
             'content-types' => [
-                '#^text/#i',
-                '#^application/json$#i',
-                '#^application/(.*\+)?xml$#i',
+                'text' => '#^text/#i',
+                'json' => '#^application/json$#i',
+                'xml' => '#^application/(.*\+)?xml$#i',
             ]
         ],
     ],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -402,7 +402,7 @@ return [
              * Array keys are the internal type identifier (so that it can be disabled)
              * Array values are regular expressions that Content-Type headers must satisfy.
              */
-            'content-types' => [
+            'content_types' => [
                 'text' => '#^text/#i',
                 'json' => '#^application/json$#i',
                 'xml' => '#^application/(.*\+)?xml$#i',

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -406,7 +406,7 @@ return [
                 'text' => '#^text/#i',
                 'json' => '#^application/json$#i',
                 'xml' => '#^application/(.*\+)?xml$#i',
-            ]
+            ],
         ],
     ],
     'jobs' => [

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -3,25 +3,23 @@
 namespace Concrete\Core\Logging;
 
 use Concrete\Core\Support\Facade\Application;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Zend\Http\Request as ZendRequest;
 use Zend\Http\Response as ZendResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\RequestInterface;
 
 /**
- * Class HttpLoggableAwareTrait
- *
  * Check if a http request or http response body can be logged (doesn't contain binary data)
  */
 trait HttpLoggableAwareTrait
 {
-
     /**
-     * Check if request body can be logged (is not binary)
+     * Check if request body can be logged (is not binary).
      *
      * @param ZendRequest|SymfonyRequest|RequestInterface $request
+     *
      * @return bool
      */
     public function isRequestBodyLoggable($request)
@@ -40,17 +38,18 @@ trait HttpLoggableAwareTrait
     }
 
     /**
-     * Check if response body can be logged (is not binary)
+     * Check if response body can be logged (is not binary).
      *
      * @param ZendResponse|SymfonyResponse|ResponseInterface $response
+     *
      * @return bool
      */
     public function isResponseBodyLoggable($response)
     {
         if ($response instanceof SymfonyResponse) {
-            $headers =  $response->headers->all();
+            $headers = $response->headers->all();
         } elseif ($response instanceof ZendResponse) {
-            $headers =  $response->getHeaders()->toArray();
+            $headers = $response->getHeaders()->toArray();
         } elseif ($response instanceof ResponseInterface) {
             $headers = $response->getHeaders();
         } else {
@@ -63,10 +62,11 @@ trait HttpLoggableAwareTrait
     /**
      * Compare the headers of the request or response with the whitelist
      * If the content type matches a entry in the whitelist,
-     * the response or request body can be logged
+     * the response or request body can be logged.
      *
      * @param array $headers
      * @param array $types
+     *
      * @return bool
      */
     public function isLoggable(array $headers, array $types)
@@ -77,7 +77,7 @@ trait HttpLoggableAwareTrait
         if (array_key_exists('content-type', $headers)) {
             $responseContentType = $headers['content-type'];
             if (is_string($responseContentType)) {
-                foreach($types as $type) {
+                foreach ($types as $type) {
                     if ($type && preg_match($type, $responseContentType)) {
                         $isLoggable = true;
                         break;
@@ -85,11 +85,12 @@ trait HttpLoggableAwareTrait
                 }
             }
         }
+
         return $isLoggable;
     }
 
     /**
-     * Get whitelist of http content types which can be logged
+     * Get whitelist of http content types which can be logged.
      *
      * @return array
      */
@@ -97,13 +98,15 @@ trait HttpLoggableAwareTrait
     {
         $app = Application::getFacadeApplication();
         $config = $app->make('config');
+
         return $config->get('concrete.log.http.content_types');
     }
 
     /**
-     * Get content-type string from response
+     * Get content-type string from response.
      *
      * @param ZendRequest|SymfonyRequest|RequestInterface $request
+     *
      * @return string
      */
     public function getRequestContentType($request)
@@ -111,9 +114,9 @@ trait HttpLoggableAwareTrait
         $contentType = '';
 
         if ($request instanceof SymfonyRequest) {
-            $contentType =  array_change_key_case($request->headers->get('content-type'));
+            $contentType = array_change_key_case($request->headers->get('content-type'));
         } elseif ($request instanceof ZendRequest) {
-            $headers =  array_change_key_case($request->getHeaders()->toArray());
+            $headers = array_change_key_case($request->getHeaders()->toArray());
             if (array_key_exists('content-type', $headers)) {
                 $contentType = $headers['content-type'];
             }
@@ -122,13 +125,15 @@ trait HttpLoggableAwareTrait
         elseif ($request instanceof RequestInterface) {
             $contentType = $request->getHeader('content-type');
         }
+
         return $contentType;
     }
 
     /**
-     * Get content-type string from response
+     * Get content-type string from response.
      *
      * @param ZendResponse|SymfonyResponse|ResponseInterface $response
+     *
      * @return string
      */
     public function getResponseContentType($response)
@@ -136,9 +141,9 @@ trait HttpLoggableAwareTrait
         $contentType = '';
 
         if ($response instanceof SymfonyResponse) {
-            $contentType =  array_change_key_case($response->headers->get('content-type'));
+            $contentType = array_change_key_case($response->headers->get('content-type'));
         } elseif ($response instanceof ZendResponse) {
-            $headers =  array_change_key_case($response->getHeaders()->toArray());
+            $headers = array_change_key_case($response->getHeaders()->toArray());
             if (array_key_exists('content-type', $headers)) {
                 $contentType = $headers['content-type'];
             }

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -97,7 +97,7 @@ trait HttpLoggableAwareTrait
     {
         $app = Application::getFacadeApplication();
         $config = $app->make('config');
-        return $config->get('concrete.log.http.content-types');
+        return $config->get('concrete.log.http.content_types');
     }
 
     /**

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -76,8 +76,7 @@ trait HttpLoggableAwareTrait
 
         if (array_key_exists('content-type', $headers)) {
             $responseContentType = $headers['content-type'];
-
-            if (is_array($types)) {
+            if (is_string($responseContentType)) {
                 foreach($types as $type) {
                     if (preg_match($type, $responseContentType)) {
                         $isLoggable = true;

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -48,11 +48,11 @@ trait HttpLoggableAwareTrait
     public function isResponseBodyLoggable($response)
     {
         if ($response instanceof SymfonyResponse) {
-            $headers =  array_change_key_case($response->headers->all());
+            $headers =  $response->headers->all();
         } elseif ($response instanceof ZendResponse) {
-            $headers =  array_change_key_case($response->getHeaders()->toArray());
+            $headers =  $response->getHeaders()->toArray();
         } elseif ($response instanceof ResponseInterface) {
-            $headers = array_change_key_case($response->getHeaders());
+            $headers = $response->getHeaders();
         } else {
             $headers = [];
         }
@@ -72,6 +72,7 @@ trait HttpLoggableAwareTrait
     public function isLoggable(array $headers, array $types)
     {
         $isLoggable = false;
+        $headers = array_change_key_case($headers);
 
         if (array_key_exists('content-type', $headers)) {
             $responseContentType = $headers['content-type'];

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -78,7 +78,7 @@ trait HttpLoggableAwareTrait
             $responseContentType = $headers['content-type'];
             if (is_string($responseContentType)) {
                 foreach($types as $type) {
-                    if (preg_match($type, $responseContentType)) {
+                    if ($type && preg_match($type, $responseContentType)) {
                         $isLoggable = true;
                         break;
                     }

--- a/tests/tests/Logging/HttpLoggableAwareTraitTest.php
+++ b/tests/tests/Logging/HttpLoggableAwareTraitTest.php
@@ -40,9 +40,10 @@ class HttpLoggableAwareTraitTest extends PHPUnit_Framework_TestCase
     public function getLoggableContentTypes()
     {
         return [
-            '#^text/#i',
-            '#^application/json$#i',
-            '#^application/(.*\+)?xml$#i',
+            'disabled' => false,
+            'text' => '#^text/#i',
+            'json' => '#^application/json$#i',
+            'xml' => '#^application/(.*\+)?xml$#i',
         ];
     }
 

--- a/tests/tests/Logging/HttpLoggableAwareTraitTest.php
+++ b/tests/tests/Logging/HttpLoggableAwareTraitTest.php
@@ -28,12 +28,12 @@ class HttpLoggableAwareTraitTest extends PHPUnit_Framework_TestCase
             [['Content-Type' => 'application/rtf'], false],
             [['Content-Type' => 'application/javascript'], false],
             [['Content-Type' => 'image/png'], false],
-            [['Content-Type' => 'image/jpeg'], false]
+            [['Content-Type' => 'image/jpeg'], false],
         ];
     }
 
     /**
-     * Stub config values from log -> http -> Content-Types
+     * Stub config values from log -> http -> Content-Types.
      *
      * @return array
      */
@@ -49,6 +49,9 @@ class HttpLoggableAwareTraitTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider contentTypesProvider
+     *
+     * @param string $contentType
+     * @param bool $expected
      */
     public function testIsLoggable($contentType, $expected)
     {

--- a/tests/tests/Logging/HttpLoggableAwareTraitTest.php
+++ b/tests/tests/Logging/HttpLoggableAwareTraitTest.php
@@ -17,23 +17,23 @@ class HttpLoggableAwareTraitTest extends PHPUnit_Framework_TestCase
         return [
             // contentType, expected
             // true = loggable http body types
-            [['content-type' => 'text/plain'], true],
-            [['content-type' => 'text/css'], true],
-            [['content-type' => 'text/html'], true],
-            [['content-type' => 'text/csv'], true],
-            [['content-type' => 'application/json'], true],
-            [['content-type' => 'application/xml'], true],
-            [['content-type' => 'application/rss+xml'], true],
+            [['Content-Type' => 'text/plain'], true],
+            [['Content-Type' => 'text/css'], true],
+            [['Content-Type' => 'text/html'], true],
+            [['Content-Type' => 'text/csv'], true],
+            [['Content-Type' => 'application/json'], true],
+            [['Content-Type' => 'application/xml'], true],
+            [['Content-Type' => 'application/rss+xml'], true],
             // false
-            [['content-type' => 'application/rtf'], false],
-            [['content-type' => 'application/javascript'], false],
-            [['content-type' => 'image/png'], false],
-            [['content-type' => 'image/jpeg'], false]
+            [['Content-Type' => 'application/rtf'], false],
+            [['Content-Type' => 'application/javascript'], false],
+            [['Content-Type' => 'image/png'], false],
+            [['Content-Type' => 'image/jpeg'], false]
         ];
     }
 
     /**
-     * Stub config values from log -> http -> content-types
+     * Stub config values from log -> http -> Content-Types
      *
      * @return array
      */


### PR DESCRIPTION
With this change, users can disable a whitelisted key (for example xml) by setting the `concrete.log.http.content_types.xml` to `false`.